### PR TITLE
Treat any description, starting with @, as a tag

### DIFF
--- a/src/main/scala/com/thoughtworks/Example.scala
+++ b/src/main/scala/com/thoughtworks/Example.scala
@@ -161,6 +161,29 @@ object Example extends AutoPlugin {
                 """
               }
               (Nil, Nil, tag :: tagAccumulator)
+            case (
+                  DocToken(DocToken.Description, None, Some(text)),
+                  (codeAccumulator, trailingAccumulator, tagAccumulator)
+                ) if text.startsWith("@") =>
+              logger.warn(
+                s"Invalid Scaladoc tag detected at ${comment.pos} (missing parameters for the tag?): \n\t$text"
+              )
+              val tag = if (codeAccumulator.nonEmpty) {
+                q"""
+                  ${Lit.String(text)}.in(try {
+                     ..$codeAccumulator
+                  } finally {
+                    ..$trailingAccumulator
+                  })
+                """
+              } else {
+                q"""
+                  ${Lit.String(text)} - {
+                    ..$trailingAccumulator
+                  }
+                """
+              }
+              (Nil, Nil, tag :: tagAccumulator)
             case (DocToken(DocToken.Paragraph, None, None), accumulators) =>
               accumulators
             case (otherToken, (codeAccumulator, trailingAccumulator, tagAccumulator)) =>

--- a/src/main/scala/com/thoughtworks/Example.scala
+++ b/src/main/scala/com/thoughtworks/Example.scala
@@ -142,12 +142,12 @@ object Example extends AutoPlugin {
               }
               (Nil, Nil, tag :: tagAccumulator)
             case (
-                  DocToken(tagKind: DocToken.TagKind, name, body),
+                  token @ DocToken(_: DocToken.TagKind, _, None),
                   (codeAccumulator, trailingAccumulator, tagAccumulator)
                 ) =>
               val tag = if (codeAccumulator.nonEmpty) {
                 q"""
-                  ${Lit.String(tagKind.label)}.-(try {
+                  ${Lit.String(token.toString)}.in(try {
                      ..$codeAccumulator
                   } finally {
                     ..$trailingAccumulator
@@ -155,7 +155,7 @@ object Example extends AutoPlugin {
                 """
               } else {
                 q"""
-                  ${Lit.String(tagKind.label)} - {
+                  ${Lit.String(token.toString)} - {
                     ..$trailingAccumulator
                   }
                 """


### PR DESCRIPTION
This would make sbt-example support the following style, which would be produced by Scalafmt:

``` scala
/**
  * @example
  *   description blah blah
  * {{{
  * val test = "executed"
  * test should be("executed")
  * }}}
  */
```