### PR TITLE
Remove repeated default

### DIFF
--- a/src/main/scala/com/thoughtworks/Example.scala
+++ b/src/main/scala/com/thoughtworks/Example.scala
@@ -349,10 +349,6 @@ object Example extends AutoPlugin {
 
   }
 
-  override def trigger: PluginTrigger = noTrigger
-
-  override def requires: Plugins = JvmPlugin
-
   /** Contains sbt setting keys, which will be automatically imported into your
     * `build.sbt`.
     *


### PR DESCRIPTION
`trigger` and `requires` are already `noTrigger` and `JvmPlugin` per default in sbt.

See: https://github.com/sbt/sbt/blob/1.10.x/main/src/main/scala/sbt/Plugins.scala#L82